### PR TITLE
Ignore error if settings.js is mounted read-only.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'node-red' -a "$(id -u)" = '0' ]; then
-    chown -R node-red:node-red /config /data
+    chown -R node-red:node-red /config /data --quiet || true
     exec su-exec node-red "$0" "$@"
 fi
 


### PR DESCRIPTION
If I download the `settings.js` as per instructions then uncomment this in the docker-compose.yml:

```
    volumes:
      - ./settings.js:/config/settings.js:ro
      - ./data:/data
```

I get this error:

```
$ docker-compose up
Starting dockernoderedgit_node-red_1 ... 
Starting dockernoderedgit_node-red_1 ... done
Attaching to dockernoderedgit_node-red_1
node-red_1  | chown: /config/settings.js: Read-only file system
dockernoderedgit_node-red_1 exited with code 1
```

If I remove the `:ro` option from the `settings.js` entry, then the container starts correctly. However it would be nice to retain the read-only attribute on the settings file. So this change allows `docker-entrypoint.sh` to ignore any errors encountered during the `chown`.

I think there's another issue where "if no configfile is provided, generate one based on the environment variables" is going to fail with a read-only mount too, but this PR doesn't address that.

